### PR TITLE
Some needed updates to remove broken links and out of date info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/nbproject/private/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/nbproject/private/
+/nbproject/*

--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@ a:visited {
             as the map rendering engine.
           </p>
         </li>
-        <li><a href="https://github.com/Maps4HTML/geoserver">GeoServer MapML MapML Community Module</a>
+        <li><a href="https://github.com/Maps4HTML/geoserver">GeoServer MapML Community Module</a>
           <p>
             A GeoServer module that enables MapML output, supporting images, 
             features and tiles. There is basic 

--- a/index.html
+++ b/index.html
@@ -212,8 +212,7 @@ a:visited {
       <ul>
         <li><a href="https://github.com/Maps4HTML/Web-Map-Custom-Element">Web-map custom element</a>
           <p>
-            A polyfill of the proposed HTML map / layer element specification,
-            with MapML support, as a set of HTML custom elements,  using Leaflet
+            A polyfill of the <a href="https://github.com/Maps4HTML/MapML-Proposal#the-mapml-proposal---explainermd">MapML proposal</a>, as a set of HTML custom elements,  using Leaflet
             as the map rendering engine.
           </p>
         </li>
@@ -225,6 +224,19 @@ a:visited {
             available, as well as 
             <a href="https://youtu.be/14XvqNf4jTE?list=PLA07raojXKMuJdyBMs32G9ChY4JQxnlbn">instructions</a> 
             on how to install the module.
+          </p>
+        </li>
+        <li><a href="https://github.com/Maps4HTML/validator-mapml">Validator.nu for MapML</a>
+          <p>
+            An experimental / work in progress fork of the validator.nu project 
+            which validates MapML documents.  The objective is to validate HTML
+            including map markup as well as independent text/mapml documents.
+          </p>
+        </li>
+        <li><a href="https://github.com/prushforth/htmlparser">HTML-MapML Parser</a>
+          <p>
+            An experimental / work in progress fork of the 
+            <a href="https://github.com/validator/htmlparser">validator.nu HTML parser</a>
           </p>
         </li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@ a:visited {
   }
 }
     </style>
+    <link rel="icon" type="image/x-icon" href="https://www.w3.org/community/src/templates/wordpress/StoryTeller/favicon.ico">
   </head>
   <body>
     <header>

--- a/index.html
+++ b/index.html
@@ -156,6 +156,9 @@ a:visited {
             (including this web page).
           </p>
         </li>
+        <li><a href="https://www.youtube.com/channel/UCKIv6IGwzxPF2HNhvq-VhKA">Maps for HTML is on YouTube</a>
+          <p>The Maps for HTML Community Group has a <a href="https://www.youtube.com/channel/UCKIv6IGwzxPF2HNhvq-VhKA" >channel</a> on YouTube.</p>
+        </li>
       </ul>
     </section>
     <section>
@@ -197,6 +200,19 @@ a:visited {
             and hyperlinks to related resources.
             MapML documents could be used as layers in an HTML map viewer.
           </p>
+        </li>
+        <li>MapML Engineering Reports from the <abbr title="Open Geospatial Consortium">OGC</abbr> Innovation Program
+            <ul>
+                <li>
+                  <a  href="https://docs.opengeospatial.org/per/17-019.html">Testbed 13</a> - early community ideas
+                </li>
+                <li>
+                  <a  href="https://docs.opengeospatial.org/per/18-023r1.html">Testbed 14</a> - improved vocabulary
+                </li>
+                <li>
+                  <a  href="https://docs.opengeospatial.org/per/19-046r1.html">Testbed 15</a> - improved vector model
+                </li>
+            </ul>
         </li>
         <li>A <a href="https://www.w3.org/community/maps4html/2019/12/09/the-design-of-mapml/">blog post</a>, detailing how the MapML proposal relates to the 
             <a href="https://www.w3.org/TR/html-design-principles/">HTML Design Principles</a>.</li>
@@ -258,22 +274,41 @@ a:visited {
         <li><a href="https://geogratis.gc.ca/mapml/static/us_pop_density.html">Vector example</a>
           <p>
             This is an HTML document containing map markup inline, representing
-            vector data according to the MapML &lt;feature&gt; proposal. </a>.
+            vector data according to the MapML &lt;feature&gt; proposal. 
           </p>
         </li>
-
-        
-<!--        <li><a href="https://geogratis.gc.ca/mapml/static/cubewerx_cgdi_proxy_geomet_directory.html">MapML versions of GeoMet WMS</a>
+      </ul>
+    </section>
+    <section>
+      <h2>Related standards and document formats</h2>
+      <p>
+        The following standards may be of relevance to maps in HTML:
+      </p>
+      <ul>
+        <li><a href="https://www.opengeospatial.org/standards/">OGC Standards and Supporting Documents</a>
           <p>
-            Direct access to MapML files,
-            generated from live CubeWerx Environment and Climate Change data.
-            These files can be dragged and dropped onto the <a href="https://geogratis.gc.ca/mapml/">MapML viewers</a>.
+            The Open Geospatial Consortium (OGC) publishes standards for map-related data,
+            some of which are used or adapted by MapML:
+          </p>
+          <ul>
+              <li><a href="https://www.opengeospatial.org/standards/wms">Web Map Service</a></li>
+              <li><a href="https://www.opengeospatial.org/standards/wmts">Web Map Tile Service</a></li>
+              <li><a href="https://www.opengeospatial.org/standards/tms">Tile Matrix Set</a></li>
+              <li><a href="https://www.opengeospatial.org/standards/sfa">Simple Features</a></li>
+          </ul>
+        </li>
+        <li><a href="http://geojson.org/">GeoJSON specification</a>
+          <p>
+            IETF standard <a href="https://tools.ietf.org/html/rfc7946">RFC 7946</a>
+            is a standardized representation of vector feature data in JSON structure.
           </p>
         </li>
-        <li><a href="https://geogratis.gc.ca/mapml/static/cubewerx_cgdi_proxy_wmts.html">Collection of MapML viewers of CubeWerx maps</a>
-        </li>-->
-        <li><a href="https://www.youtube.com/channel/UCKIv6IGwzxPF2HNhvq-VhKA" target="_blank">Maps for HTML is on YouTube</a>
-          <p>The Maps for HTML Community Group has a <a href="https://www.youtube.com/channel/UCKIv6IGwzxPF2HNhvq-VhKA" target="_blank">channel</a> on YouTube.</p>
+        <li><a href="https://tools.ietf.org/html/rfc5870">Geo URI specification</a>
+          <p>
+            IETF RFC <a href="https://tools.ietf.org/html/rfc5870">RFC 5870</a>
+            is a URI scheme allowing WGS 84 locations to be conveyed in URLs
+            conforming to a specified URI scheme.
+          </p>
         </li>
       </ul>
     </section>
@@ -285,23 +320,6 @@ a:visited {
         may be of interest:
       </p>
       <ul>
-        <li><a href="https://www.opengeospatial.org/standards/">OGC® Standards and Supporting Documents</a>
-          <p>
-            The Open Geospatial Consortium (OGC) publishes standards for map-related data,
-            some of which are used or adapted by MapML.
-          </p>
-        </li>
-        <li>MapML Engineering Reports from the <abbr title="Open Geospatial Consortium">OGC</abbr> Innovation Program
-          <p>
-            <a target="_blank" href="https://docs.opengeospatial.org/per/17-019.html">Testbed 13</a> - early community ideas
-          </p>
-          <p>
-            <a target="_blank" href="https://docs.opengeospatial.org/per/18-023r1.html">Testbed 14</a> - improved vocabulary
-          </p>
-          <p>
-            <a target="_blank" href="https://docs.opengeospatial.org/per/19-046r1.html">Testbed 15</a> - improved vector model
-          </p>
-        </li>
         <li><a href="https://www.w3.org/TR/2017/NOTE-sdw-bp-20170928/">Spatial Data on the Web Best Practices</a>
           and <a href="https://w3c.github.io/sdw/UseCases/SDWUseCasesAndRequirements.html">Use Cases and Requirements</a>
           <p>
@@ -330,27 +348,6 @@ a:visited {
             See the related proposals for standardizing key new SVG features:
             <a href="https://www.w3.org/Submission/2011/SUBM-SVGTL-20110607/">SVG Tiling and Layering Module (proposal)</a>
             and <a href="https://www.w3.org/Graphics/SVG/WG/wiki/Proposals/globalView">SVG globalView proposal</a>
-          </p>
-        </li>
-      </ul>
-    </section>
-    <section>
-      <h2>RFCs and other relevant documents</h2>
-      <p>
-        The following standards may be of relevance to maps in HTML:
-      </p>
-      <ul>
-        <li><a href="http://geojson.org/">GeoJSON specification</a>
-          <p>
-            IETF standard <a href="https://tools.ietf.org/html/rfc7946">RFC 7946</a>
-            is a standardized representation of vector feature data in JSON structure.
-          </p>
-        </li>
-        <li><a href="https://tools.ietf.org/html/rfc5870">Geo URI specification</a>
-          <p>
-            IETF RFC <a href="https://tools.ietf.org/html/rfc5870">RFC 5870</a>
-            is a URI scheme allowing WGS 84 locations to be conveyed in URLs
-            conforming to a specified URI scheme.
           </p>
         </li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -171,6 +171,16 @@ a:visited {
             which can combine multiple layers into an interactive view.
           </p>
         </li>
+        <li>
+            An explainer of the 
+            <a href="https://github.com/Maps4HTML/MapML-Proposal#the-mapml-proposal---explainermd">MapML proposal</a>.  
+            The explainer is based on a <a href="https://w3ctag.github.io/explainers">template</a> 
+            recommended by the W3C TAG, and may be the best place to start in 
+            trying to understand the substance of the MapML proposal.  The 
+            "MapML Proposal" relates to the following two proposed specifications,
+            which are slightly out of date and need to be revised.  GitHub
+            issues in the explainer repository can be used to identify problems.
+        </li>
         <li><a href="https://maps4html.github.io/HTML-Map-Element/spec/">HTML map element specification</a>
           (<a href="https://github.com/Maps4HTML/HTML-Map-Element">GitHub repository</a>)
           <p>
@@ -187,6 +197,8 @@ a:visited {
             MapML documents could be used as layers in an HTML map viewer.
           </p>
         </li>
+        <li>A <a href="https://www.w3.org/community/maps4html/2019/12/09/the-design-of-mapml/">blog post</a>, detailing how the MapML proposal relates to the 
+            <a href="https://www.w3.org/TR/html-design-principles/">HTML Design Principles</a>.</li>
       </ul>
     </section>
     <section>
@@ -197,26 +209,21 @@ a:visited {
         make it possible to experiment with the proposed specifications:
       </p>
       <ul>
-        <li><a href="https://github.com/Maps4HTML/Web-Map-Custom-Element">Web map custom element</a>
+        <li><a href="https://github.com/Maps4HTML/Web-Map-Custom-Element">Web-map custom element</a>
           <p>
-            A recreation of the HTML map element specification,
-            with MapML support,
-            an an HTML custom element,
-            using Leaflet to display the maps.
-          </p>
-          <p>
-            Note: The code currently uses the “version 0” custom elements API,
-            and therefore requires the Polymer polyfills to work.
+            A polyfill of the proposed HTML map / layer element specification,
+            with MapML support, as a set of HTML custom elements,  using Leaflet
+            as the map rendering engine.
           </p>
         </li>
-        <li><a href="https://github.com/Maps4HTML/MapML-Leaflet-Plugin">MapML Leaflet Plugin</a>
+        <li><a href="https://github.com/Maps4HTML/geoserver">GeoServer MapML MapML Community Module</a>
           <p>
-            The code that allows Leaflet to support MapML layers.
-          </p>
-        </li>
-        <li><a href="https://github.com/Maps4HTML/MapMLServer">MapML Server</a>
-          <p>
-            A Java servlet for Apache Tomcat for fetching MapML requests.
+            A GeoServer module that enables MapML output, supporting images, 
+            features and tiles. There is basic 
+            <a href="https://docs.geoserver.org/latest/en/user/community/mapml/index.html">documentation</a> 
+            available, as well as 
+            <a href="https://youtu.be/14XvqNf4jTE?list=PLA07raojXKMuJdyBMs32G9ChY4JQxnlbn">instructions</a> 
+            on how to install the module.
           </p>
         </li>
       </ul>
@@ -235,7 +242,15 @@ a:visited {
             including arctic views (not supported by most web map tiling systems).
           </p>
         </li>
-        <li><a href="https://geogratis.gc.ca/mapml/static/cubewerx_cgdi_proxy_geomet_directory.html">MapML versions of GeoMet WMS</a>
+        <li><a href="https://geogratis.gc.ca/mapml/static/us_pop_density.html">Vector example</a>
+          <p>
+            This is an HTML document containing map markup inline, representing
+            vector data according to the MapML &lt;feature&gt; proposal. </a>.
+          </p>
+        </li>
+        https://geogratis.gc.ca/mapml/static/us_pop_density.html
+        
+<!--        <li><a href="https://geogratis.gc.ca/mapml/static/cubewerx_cgdi_proxy_geomet_directory.html">MapML versions of GeoMet WMS</a>
           <p>
             Direct access to MapML files,
             generated from live CubeWerx Environment and Climate Change data.
@@ -243,7 +258,7 @@ a:visited {
           </p>
         </li>
         <li><a href="https://geogratis.gc.ca/mapml/static/cubewerx_cgdi_proxy_wmts.html">Collection of MapML viewers of CubeWerx maps</a>
-        </li>
+        </li>-->
       </ul>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -261,7 +261,7 @@ a:visited {
             vector data according to the MapML &lt;feature&gt; proposal. </a>.
           </p>
         </li>
-        https://geogratis.gc.ca/mapml/static/us_pop_density.html
+
         
 <!--        <li><a href="https://geogratis.gc.ca/mapml/static/cubewerx_cgdi_proxy_geomet_directory.html">MapML versions of GeoMet WMS</a>
           <p>
@@ -272,6 +272,9 @@ a:visited {
         </li>
         <li><a href="https://geogratis.gc.ca/mapml/static/cubewerx_cgdi_proxy_wmts.html">Collection of MapML viewers of CubeWerx maps</a>
         </li>-->
+        <li><a href="https://www.youtube.com/channel/UCKIv6IGwzxPF2HNhvq-VhKA" target="_blank">Maps for HTML is on YouTube</a>
+          <p>The Maps for HTML Community Group has a <a href="https://www.youtube.com/channel/UCKIv6IGwzxPF2HNhvq-VhKA" target="_blank">channel</a> on YouTube.</p>
+        </li>
       </ul>
     </section>
     <section>
@@ -285,16 +288,18 @@ a:visited {
         <li><a href="https://www.opengeospatial.org/standards/">OGC® Standards and Supporting Documents</a>
           <p>
             The Open Geospatial Consortium (OGC) publishes standards for map-related data,
-            many of which are used or adapted for MapML.
+            some of which are used or adapted by MapML.
           </p>
         </li>
-        <li><a href="https://docs.opengeospatial.org/per/17-019.html">MapML Engineering Report (2017)</a> from the <abbr title="Open Geospatial Consortium">OGC</abbr> Testbed 13
+        <li>MapML Engineering Reports from the <abbr title="Open Geospatial Consortium">OGC</abbr> Innovation Program
           <p>
-            Reviews the MapML spec (as it was at the time)
-            and experimental implementations for serving and using MapML documents.
-            Some of the recommendations have since been integrated in the specification,
-            or otherwise made redundant.
-            A follow-up report will be published as part of OGC Testbed 14.
+            <a target="_blank" href="https://docs.opengeospatial.org/per/17-019.html">Testbed 13</a> - early community ideas
+          </p>
+          <p>
+            <a target="_blank" href="https://docs.opengeospatial.org/per/18-023r1.html">Testbed 14</a> - improved vocabulary
+          </p>
+          <p>
+            <a target="_blank" href="https://docs.opengeospatial.org/per/19-046r1.html">Testbed 15</a> - improved vector model
           </p>
         </li>
         <li><a href="https://www.w3.org/TR/2017/NOTE-sdw-bp-20170928/">Spatial Data on the Web Best Practices</a>
@@ -306,16 +311,14 @@ a:visited {
             Some of the recommendations are relevant to map viewers and map data servers.
           </p>
         </li>
-        <li><a href="https://leafletjs.com/">Leaflet</a>
+        <li><a href="https://openlayers.org/">OpenLayers</a>
           <p>
-            A JavaScript API for building custom map viewers on the web,
-            used in the web-map custom element.
+            An open source JavaScript library for building custom Web maps.
           </p>
         </li>
-        <li><a href="http://geojson.org/">GeoJSON specification</a>
+        <li><a href="https://leafletjs.com/">Leaflet</a>
           <p>
-            IETF standard <a href="https://tools.ietf.org/html/rfc7946">RFC 7946</a>
-            is a standardized representation of vector feature data in JSON structure.
+            An open source JavaScript library for building custom Web maps.
           </p>
         </li>
         <li><a href="https://www.svgmap.org/">SVGMap</a>
@@ -327,6 +330,27 @@ a:visited {
             See the related proposals for standardizing key new SVG features:
             <a href="https://www.w3.org/Submission/2011/SUBM-SVGTL-20110607/">SVG Tiling and Layering Module (proposal)</a>
             and <a href="https://www.w3.org/Graphics/SVG/WG/wiki/Proposals/globalView">SVG globalView proposal</a>
+          </p>
+        </li>
+      </ul>
+    </section>
+    <section>
+      <h2>RFCs and other relevant documents</h2>
+      <p>
+        The following standards may be of relevance to maps in HTML:
+      </p>
+      <ul>
+        <li><a href="http://geojson.org/">GeoJSON specification</a>
+          <p>
+            IETF standard <a href="https://tools.ietf.org/html/rfc7946">RFC 7946</a>
+            is a standardized representation of vector feature data in JSON structure.
+          </p>
+        </li>
+        <li><a href="https://tools.ietf.org/html/rfc5870">Geo URI specification</a>
+          <p>
+            IETF RFC <a href="https://tools.ietf.org/html/rfc5870">RFC 5870</a>
+            is a URI scheme allowing WGS 84 locations to be conveyed in URLs
+            conforming to a specified URI scheme.
           </p>
         </li>
       </ul>


### PR DESCRIPTION
- Remove cubewerx examples
- Remove link to mapml-client library
- Add links to explainer and meta-explainer blog post
- Replace link to MapML Servlet with links to GeoServer MapML Community Module