### PR TITLE
Update homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,19 +185,16 @@ a:visited {
             which are slightly out of date and need to be revised.  GitHub
             issues in the explainer repository can be used to identify problems.
         </li>
-        <li><a href="https://maps4html.github.io/HTML-Map-Element/spec/">HTML map element specification</a>
-          (<a href="https://github.com/Maps4HTML/HTML-Map-Element">GitHub repository</a>)
-          <p>
-            A proposal for how the HTML map viewer and layer elements could be defined.
-          </p>
-        </li>
-        <li><a href="https://maps4html.github.io/MapML/spec/">MapML specification</a>
+        <li><a href="https://maps4html.org/MapML/spec/">MapML specification</a>
           (<a href="https://github.com/Maps4HTML/MapML">GitHub repository</a>)
           <p>
-            A proposal for a new document format for describing maps (MapML),
+            Map Markup Language (MapML) is a proposal for a new document format for describing maps,
             which could contain a mix of tiled images,
             vector features (e.g., points, lines, polygons),
             and hyperlinks to related resources.
+          </p>
+          <p>
+            Includes a proposal for how the HTML map viewer and layer elements could be defined.
             MapML documents could be used as layers in an HTML map viewer.
           </p>
         </li>

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@ a:visited {
         (which are all drafts and subject to change):
       </p>
       <ul>
-        <li><a href="https://maps4html.github.io/HTML-Map-Element-UseCases-Requirements/">HTML map element: Use Cases and Requirements</a>
+        <li><a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/">Use Cases and Requirements for Standardizing Web Maps</a>
           (<a href="https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements">GitHub repository</a>)
           <p>
             An overview of why HTML needs a built-in map viewer element,


### PR DESCRIPTION
- [x] Change "HTML map element: Use Cases and Requirements" to "Use Cases and Requirements for Standardizing Web Maps", because that's what the report is named, and because it's immediately clearer to newcomers what the report (the link) is about.
- [x] Remove link to [HTML Map Element](https://maps4html.org/HTML-Map-Element/spec/) specification as it was merged into the MapML spec, [here](https://maps4html.org/MapML/spec/#web-maps).