### PR TITLE
Updates/additions of links

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@ a:visited {
         </li>
         <li>
             An explainer of the 
-            <a href="https://github.com/Maps4HTML/MapML-Proposal#the-mapml-proposal---explainermd">MapML proposal</a>.  
+            <a href="https://github.com/Maps4HTML/MapML-Proposal">MapML proposal</a>.  
             The explainer is based on a <a href="https://w3ctag.github.io/explainers">template</a> 
             recommended by the W3C TAG, and may be the best place to start in 
             trying to understand the substance of the MapML proposal.  The 
@@ -225,7 +225,7 @@ a:visited {
       <ul>
         <li><a href="https://github.com/Maps4HTML/Web-Map-Custom-Element">Web-map custom element</a>
           <p>
-            A polyfill of the <a href="https://github.com/Maps4HTML/MapML-Proposal#the-mapml-proposal---explainermd">MapML proposal</a>, as a set of HTML custom elements,  using Leaflet
+            A polyfill of the <a href="https://github.com/Maps4HTML/MapML-Proposal">MapML proposal</a>, as a set of HTML custom elements,  using Leaflet
             as the map rendering engine.
           </p>
         </li>
@@ -294,7 +294,7 @@ a:visited {
               <li><a href="https://www.opengeospatial.org/standards/sfa">Simple Features</a></li>
           </ul>
         </li>
-        <li><a href="http://geojson.org/">GeoJSON specification</a>
+        <li><a href="https://geojson.org/">GeoJSON specification</a>
           <p>
             IETF standard <a href="https://tools.ietf.org/html/rfc7946">RFC 7946</a>
             is a standardized representation of vector feature data in JSON structure.
@@ -320,8 +320,8 @@ a:visited {
         may be of interest:
       </p>
       <ul>
-        <li><a href="https://www.w3.org/TR/2017/NOTE-sdw-bp-20170928/">Spatial Data on the Web Best Practices</a>
-          and <a href="https://w3c.github.io/sdw/UseCases/SDWUseCasesAndRequirements.html">Use Cases and Requirements</a>
+        <li><a href="https://www.w3.org/TR/sdw-bp/">Spatial Data on the Web Best Practices</a>
+          and <a href="https://www.w3.org/TR/sdw-ucr/">Use Cases and Requirements</a>
           <p>
             These reports were prepared by
             the <a href="https://www.w3.org/2017/sdwig/">Spatial Data on the Web Working Group (now Interest Group)</a>,
@@ -346,7 +346,7 @@ a:visited {
           </p>
           <p>
             See the related proposals for standardizing key new SVG features:
-            <a href="https://www.w3.org/Submission/2011/SUBM-SVGTL-20110607/">SVG Tiling and Layering Module (proposal)</a>
+            <a href="https://www.w3.org/Submission/SVGTL/">SVG Tiling and Layering Module (proposal)</a>
             and <a href="https://www.w3.org/Graphics/SVG/WG/wiki/Proposals/globalView">SVG globalView proposal</a>
           </p>
         </li>

--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@ a:visited {
     <section>
       <h2>Specifications and Reports</h2>
       <p>
-        The group is currently working on three reports
+        The group is currently working on four reports
         (which are all drafts and subject to change):
       </p>
       <ul>
@@ -196,6 +196,13 @@ a:visited {
           <p>
             Includes a proposal for how the HTML map viewer and layer elements could be defined.
             MapML documents could be used as layers in an HTML map viewer.
+          </p>
+        </li>
+        <li><a href="https://maps4html.org/UCR-MapML-Matrix/mapml-ucrs-fulfillment-matrix.html">MapML UCR Fullfillment Matrix</a>
+          (<a href="https://github.com/Maps4HTML/UCR-MapML-Matrix">GitHub repository</a>)
+          <p>
+            Hosted examples and documents how MapML and existing popular web mapping libraries fulfill the
+            Use Cases and Requirements for Standardizing Web Maps.
           </p>
         </li>
         <li>MapML Engineering Reports from the <abbr title="Open Geospatial Consortium">OGC</abbr> Innovation Program

--- a/index.html
+++ b/index.html
@@ -180,10 +180,7 @@ a:visited {
             <a href="https://github.com/Maps4HTML/MapML-Proposal">MapML proposal</a>.  
             The explainer is based on a <a href="https://w3ctag.github.io/explainers">template</a> 
             recommended by the W3C TAG, and may be the best place to start in 
-            trying to understand the substance of the MapML proposal.  The 
-            "MapML Proposal" relates to the following two proposed specifications,
-            which are slightly out of date and need to be revised.  GitHub
-            issues in the explainer repository can be used to identify problems.
+            trying to understand the substance of the MapML proposal.
         </li>
         <li><a href="https://maps4html.org/MapML/spec/">MapML specification</a>
           (<a href="https://github.com/Maps4HTML/MapML">GitHub repository</a>)

--- a/index.html
+++ b/index.html
@@ -329,6 +329,11 @@ a:visited {
             Some of the recommendations are relevant to map viewers and map data servers.
           </p>
         </li>
+        <li><a href="https://www.w3.org/TR/responsible-use-spatial/">The Responsible Use of Spatial Data</a>
+          <p>
+            A report on responsible use of Spatial Data on the web by the Spatial Data on the Web Interest Group.
+          </p>
+        </li>
         <li><a href="https://openlayers.org/">OpenLayers</a>
           <p>
             An open source JavaScript library for building custom Web maps.


### PR DESCRIPTION
- https://github.com/Maps4HTML/Maps4HTML.github.io/commit/b6150ec61f5b5904974d9ee3d7a91459aab84176 ensures we link to the latest version of the given publication.
- https://github.com/Maps4HTML/Maps4HTML.github.io/commit/8bd2b7aa15a2c9b785af94bbaf3009127686fae0 adds a links to The Responsible Use of Spatial Data (under "Other links").
- https://github.com/Maps4HTML/Maps4HTML.github.io/commit/af9083a4be64b8201884352d55c80bbe7a769c9c adds links to the MapML UCR Fullfillment Matrix site & repo (under "Specifications and Reports").
- https://github.com/Maps4HTML/Maps4HTML.github.io/commit/955741cff015b324c0510500221409037c36ba56 removes a sentence which I think is also referring to the obsolete HTML-Map-Element spec.