### PR TITLE
Small visual update (on-page logo, bg-color), add section anchors

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,8 +99,7 @@ a:visited {
   .logo {
     margin: 4rem auto;
     height: auto;
-    width: 100%;
-    max-width: 40vw;
+    max-width: 100%;
   }
   
   li {

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ html {
 body {
   margin: 0;
 
-  background: #eaeaff;
+  background: #dbe8d9;
   color: #003810;
 
   font-family: Verdana, sans-serif;

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ body {
   color: #003810;
 
   font-family: Verdana, sans-serif;
-  line-height: 1.4;
+  line-height: 1.5;
 
   display: grid;
 }
@@ -54,7 +54,6 @@ footer {
 h1, h2, h3, h4, h5, h6 {
   margin: 0 -1em;
   padding: 0.2em 1em;
-  line-height: 1;
   background: hsla(0,0%,100%,0.5)
 }
 
@@ -86,6 +85,13 @@ a:link {
 
 a:visited {
     color: #626;
+}
+
+.anchor {
+  background: transparent;
+  font-size: 80%;
+  vertical-align: text-bottom;
+  text-decoration: none;
 }
 
 .logo {
@@ -161,7 +167,7 @@ a:visited {
       </p>
     </header>
     <section>
-      <h2>About the Community Group</h2>
+      <h2 id="about"><a href="#about" class="anchor">🔗</a> About the Community Group</h2>
       <img class="logo" src="./assets/maps4html_512x512.png" width="192" height="192" alt="Maps for HTML">
       <p>
         The Maps for HTML Community Group is working to standardize
@@ -219,7 +225,7 @@ a:visited {
       </ul>
     </section>
     <section>
-      <h2>Specifications and Reports</h2>
+      <h2 id="specifications-and-reports"><a href="#specifications-and-reports" class="anchor">🔗</a> Specifications and Reports</h2>
       <p>
         The group is currently working on four reports
         (which are all drafts and subject to change):
@@ -279,7 +285,7 @@ a:visited {
       </ul>
     </section>
     <section>
-      <h2>Software projects</h2>
+      <h2 id="software-projects"><a href="#software-projects" class="anchor">🔗</a> Software projects</h2>
       <p>
         The following projects
         (hosted by the community group's GitHub account)
@@ -316,7 +322,7 @@ a:visited {
       </ul>
     </section>
     <section>
-      <h2>Working Demos</h2>
+      <h2 id="demos"><a href="#demos" class="anchor">🔗</a> Working Demos</h2>
       <p>
         Websites that use the custom element and MapML server,
         hosted by Natural Resources Canada.
@@ -338,7 +344,7 @@ a:visited {
       </ul>
     </section>
     <section>
-      <h2>Related standards and document formats</h2>
+      <h2 id="related-standards"><a href="#related-standards" class="anchor">🔗</a> Related standards and document formats</h2>
       <p>
         The following standards may be of relevance to maps in HTML:
       </p>
@@ -377,7 +383,7 @@ a:visited {
       </ul>
     </section>
     <section>
-      <h2>Other links</h2>
+      <h2 id="other-links"><a href="#other-links" class="anchor">🔗</a> Other links</h2>
       <p>
         The following related projects
         aren't controlled or published by the community group, but

--- a/index.html
+++ b/index.html
@@ -20,6 +20,11 @@
 *, ::before, ::after {
   box-sizing: border-box;
 }
+
+html {
+  overflow-x: hidden;
+}
+
 body {
   margin: 0;
 

--- a/index.html
+++ b/index.html
@@ -30,7 +30,6 @@ body {
   line-height: 1.4;
 
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(35em, 1fr));
 }
 
 header, footer, section {
@@ -108,6 +107,10 @@ a:visited {
 }
 
 @media (min-width: 1200px) {
+  body {
+    grid-template-columns: repeat(auto-fill, minmax(35em, 1fr));
+  }
+  
   header, footer, section {
     padding: 1em;
     max-width: 45em;

--- a/index.html
+++ b/index.html
@@ -362,7 +362,10 @@ a:visited {
           </p>
         </li>
         <li>
-          <a href="https://github.com/w3c/csswg-drafts/issues/5275">CSSWG proposal: CSS primitive for per-element panning and zooming</a>
+          <a href="https://github.com/w3c/csswg-drafts/issues/5275">Pan and Zoom CSSWG proposal</a>
+          <p>
+            A proposed CSS primitive for per-element panning and zooming.
+          </p>
         </li>
       </ul>
     </section>

--- a/index.html
+++ b/index.html
@@ -36,21 +36,15 @@ body {
 header, footer, section {
   margin: 0;
   padding: 1em;
-  max-width: 45em;
 }
 
 header, footer {
   grid-column: 1 / -1;
 }
 
-section:nth-of-type(odd) {
-  margin-left: auto;
-  justify-self: end;
-}
-
 footer {
   border-top: dotted thin;
-  margin: auto;
+  margin: 0 auto;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -90,6 +84,44 @@ a:visited {
     color: #626;
 }
 
+.logo {
+  display: block;
+  -webkit-user-drag: none;
+  -webkit-user-select: none;
+          user-select: none;
+}
+
+@media (max-width: 1199px) {
+  body {
+    padding: 0 2rem;
+  }
+  
+  .logo {
+    margin: 4rem auto;
+    height: auto;
+    width: 100%;
+    max-width: 40vw;
+  }
+  
+  li {
+    margin: 1.5em 0;
+  }
+}
+
+@media (min-width: 1200px) {
+  header, footer, section {
+    padding: 1em;
+    max-width: 45em;
+  }
+  
+  .logo {
+    padding: 1rem;
+    float: left;
+    -webkit-shape-outside: circle(50%);
+            shape-outside: circle(50%);
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   body {
     color: #d8e0ff;
@@ -123,9 +155,12 @@ a:visited {
     </header>
     <section>
       <h2>About the Community Group</h2>
+      <img class="logo" src="./assets/maps4html_512x512.png" width="192" height="192" alt="Maps for HTML">
       <p>
-        The Maps for HTML community group is working to standardize
-        methods of defining interactive geographic maps for websites.
+        The Maps for HTML Community Group is working to standardize
+        methods of defining interactive geographic maps for the web.
+      </p>
+      <p>
         The community group is hosted by the W3C (World Wide Web Consortium),
         and is open to anyone who is interested in maps and web standards.
       </p>


### PR DESCRIPTION
@prushforth WDYT?

## Preview

### Light mode

New background-color in Light mode, mostly because I think it goes well with the on-page logo and also better matches the background-color currently used in Dark mode.

<img width="800" src="https://user-images.githubusercontent.com/26493779/119137295-f53cae00-ba40-11eb-96dd-9576223aaf6c.png">

### Dark mode
<img width="800" src="https://user-images.githubusercontent.com/26493779/119137298-f5d54480-ba40-11eb-92b6-c6babd01c4d8.png">
