### PR TITLE
Update document title (SEO)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Maps4HTML Community Group Pages</title>
+    <title>Maps for HTML – Standardizing map viewers on the web</title>
     <meta name="description" content="The W3C Maps for HTML community group is working to standardize methods of defining interactive geographic maps for websites.">
     <meta property="og:title" content="Maps for HTML Community Group">
     <meta property="og:description" content="The W3C Maps for HTML community group is working to standardize methods of defining interactive geographic maps for websites.">


### PR DESCRIPTION
maps4html.org does not appear in my search engine's results (on page 1) when searching for <q>maps for html</q>, changing the title from <q>maps4html</q> to <q>maps for html</q> increases the relevance for those keywords.

Additionally this change makes the title unique (currently it's basically the same as the `<title>` for the CG's home page at w3.org).

The <q>Standardizing map viewers on the web</q> part gives the user some context to what Maps for HTML is, but this can be something else.