### PR TITLE
Update links that redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@ summary {
             Look for the “Get involved” heading
             and the “Join this group” link.
             You'll need to create a W3C website account,
-            and accept the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement</a>.
+            and accept the <a href="https://www.w3.org/community/about/process/cla/">W3C Community Contributor License Agreement</a>.
             If you have an employer with rights to work you create,
             they may need to join on your behalf.
           </p>
@@ -476,16 +476,16 @@ summary {
         The following standards may be of relevance to maps in HTML:
       </p>
       <ul>
-        <li><a href="https://www.opengeospatial.org/standards/">OGC Standards and Supporting Documents</a>
+        <li><a href="https://www.ogc.org/standards/">OGC Standards and Supporting Documents</a>
           <p>
             The Open Geospatial Consortium (OGC) publishes standards for map-related data,
             some of which are used or adapted by MapML:
           </p>
           <ul>
-              <li><a href="https://www.opengeospatial.org/standards/wms">Web Map Service</a></li>
-              <li><a href="https://www.opengeospatial.org/standards/wmts">Web Map Tile Service</a></li>
-              <li><a href="https://www.opengeospatial.org/standards/tms">Tile Matrix Set</a></li>
-              <li><a href="https://www.opengeospatial.org/standards/sfa">Simple Features</a></li>
+              <li><a href="https://www.ogc.org/standards/wms">Web Map Service</a></li>
+              <li><a href="https://www.ogc.org/standards/wmts">Web Map Tile Service</a></li>
+              <li><a href="https://www.ogc.org/standards/tms">Tile Matrix Set</a></li>
+              <li><a href="https://www.ogc.org/standards/sfa">Simple Features</a></li>
           </ul>
         </li>
         <li><a href="https://geojson.org/">GeoJSON specification</a>


### PR DESCRIPTION
The link checker (https://validator.w3.org/checklink?uri=https%3A%2F%2Fmaps4html.org) caught a few URLs that redirect to new locations, changing accordingly.