### PR TITLE
Updates to the Related Standards and Other Links sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -601,15 +601,12 @@ summary {
         may be of interest:
       </p>
       <ul>
-        <li><a href="https://openlayers.org/">OpenLayers</a>
-          <p>
-            An open source JavaScript library for building custom Web maps.
-          </p>
-        </li>
-        <li><a href="https://leafletjs.com/">Leaflet</a>
-          <p>
-            An open source JavaScript library for building custom Web maps.
-          </p>
+        <li>
+          Open source JavaScript libraries for building custom Web maps:
+          <ul>
+            <li><a href="https://openlayers.org/">OpenLayers</a></li>
+            <li><a href="https://leafletjs.com/">Leaflet</a></li>
+          </ul>
         </li>
         <li><a href="https://www.svgmap.org/">SVGMap</a>
           <p>

--- a/index.html
+++ b/index.html
@@ -521,6 +521,12 @@ summary {
             A report on responsible use of Spatial Data on the web by the Spatial Data on the Web Interest Group.
           </p>
         </li>
+        <li>
+          <a href="https://w3c.github.io/sdw/proposals/geotagging/webvmt/">The Web Video Map Tracks Format (WebVMT)</a>
+          <p>
+            A proposed standard for <q>video geotagging</q> to enable synchronizing map presentation to video content.
+          </p>
+        </li>
       </ul>
     </section>
     <section id="events">

--- a/index.html
+++ b/index.html
@@ -507,6 +507,20 @@ summary {
             A proposed CSS primitive for per-element panning and zooming.
           </p>
         </li>
+        <li><a href="https://www.w3.org/TR/sdw-bp/">Spatial Data on the Web Best Practices</a>
+          and <a href="https://www.w3.org/TR/sdw-ucr/">Use Cases and Requirements</a>
+          <p>
+            These reports were prepared by
+            the <a href="https://www.w3.org/2017/sdwig/">Spatial Data on the Web Working Group (now Interest Group)</a>,
+            a joint project of the OGC and W3C.
+            Some of the recommendations are relevant to map viewers and map data servers.
+          </p>
+        </li>
+        <li><a href="https://www.w3.org/TR/responsible-use-spatial/">The Responsible Use of Spatial Data</a>
+          <p>
+            A report on responsible use of Spatial Data on the web by the Spatial Data on the Web Interest Group.
+          </p>
+        </li>
       </ul>
     </section>
     <section id="events">
@@ -587,20 +601,6 @@ summary {
         may be of interest:
       </p>
       <ul>
-        <li><a href="https://www.w3.org/TR/sdw-bp/">Spatial Data on the Web Best Practices</a>
-          and <a href="https://www.w3.org/TR/sdw-ucr/">Use Cases and Requirements</a>
-          <p>
-            These reports were prepared by
-            the <a href="https://www.w3.org/2017/sdwig/">Spatial Data on the Web Working Group (now Interest Group)</a>,
-            a joint project of the OGC and W3C.
-            Some of the recommendations are relevant to map viewers and map data servers.
-          </p>
-        </li>
-        <li><a href="https://www.w3.org/TR/responsible-use-spatial/">The Responsible Use of Spatial Data</a>
-          <p>
-            A report on responsible use of Spatial Data on the web by the Spatial Data on the Web Interest Group.
-          </p>
-        </li>
         <li><a href="https://openlayers.org/">OpenLayers</a>
           <p>
             An open source JavaScript library for building custom Web maps.


### PR DESCRIPTION
- [x] https://github.com/Maps4HTML/Maps4HTML.github.io/commit/9981f6705e10713a990f0820ceb3e6ef696afa2d moves the SDW links from 'Other links' to 'Related standards and document formats', which I think is more appropriate.
- [x] https://github.com/Maps4HTML/Maps4HTML.github.io/commit/fa2e076a2db2d1321235ad352ca2c005fe1ce561 turns the open source JS links into a list with a shared description.
- [x] https://github.com/Maps4HTML/Maps4HTML.github.io/commit/100bf6f2deb11b3a3b6394a60d4006c1c08e070d adds the proposed WebVMT Format to Related standards.