### PR TITLE
Update About section

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,10 +79,6 @@ li {
   margin-bottom: 1em;
 }
 
-li p {
-  margin: 0.3em 0;
-}
-
 a {
   font-weight: 600;
   background: hsla(0,0%,100%,0.5);
@@ -389,18 +385,27 @@ button[type="share"] {
       <ul>
         <li><a href="https://www.w3.org/community/maps4html/">Maps for HTML Community Group homepage on w3.org</a>
           <p>
-            Includes a blog (infrequently updated),
-            along with other information such as
-            links to the group's draft reports,
-            links to the group's mailing list, social media, and forums,
-            and lists of current participants and chairs.
+            Includes a blog,
+            lists of
+            <a href="https://www.w3.org/community/maps4html/participants">
+             current participants and chairs
+            </a>,
+            along with other information (most of which is also available here)
+            such as links to the group's draft reports and social media.
           </p>
           <p>
-            Most importantly of all,
-            <em>this is where you join the group!</em>
-            Look for the “Get involved” heading
-            and the “Join this group” link.
-            You'll need to create a W3C website account,
+            <strong>Most importantly of all</strong>,
+            <em>this is where you
+              <a href="https://www.w3.org/community/wp-login.php?redirect_to=%2Fcommunity%2Fmaps4html%2Fjoin">
+              join the Maps for HTML Community Group!
+              </a>
+            </em>
+          </p>
+          <p>
+            To join the community group you'll need to
+            <a href="https://www.w3.org/accounts/request">
+              create a W3C account
+            </a>,
             and accept the <a href="https://www.w3.org/community/about/process/cla/">W3C Community Contributor License Agreement</a>.
             If you have an employer with rights to work you create,
             they may need to join on your behalf.


### PR DESCRIPTION
I've shortened the first paragraph in the "About the Community Group" section, so that the reader can get to the important part quicker: Joining the group!

I've also included links to:
- <q>[current participants and chairs](https://www.w3.org/community/maps4html/participants)</q>
- <q>[join the Maps for HTML Community Group!](https://www.w3.org/community/wp-login.php?redirect_to=%2Fcommunity%2Fmaps4html%2Fjoin)</q>
- <q>[create a W3C account](https://www.w3.org/accounts/request)</q>

This should make it easier for newcomers to join the CG. 🙂