### PR TITLE
Add links to Software Projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -537,6 +537,11 @@ button[type="share"] {
             A polyfill of the <a href="https://github.com/Maps4HTML/MapML-Proposal">MapML proposal</a>, as a set of HTML custom elements,  using Leaflet
             as the map rendering engine.
           </p>
+          <p>
+            See hosted
+            <a href="https://maps4html.org/experiments/">experiments</a> and
+            <a href="https://maps4html.org/web-map-doc/">documentation</a> for the MapML-viewer polyfill.
+          </p>
         </li>
         <li><a href="https://github.com/Maps4HTML/geoserver">GeoServer MapML Extension</a>
           <p>
@@ -546,17 +551,28 @@ button[type="share"] {
             available on how to install the module.
           </p>
         </li>
-        <li><a href="https://github.com/Maps4HTML/validator-mapml">Validator.nu for MapML</a>
+        <li><a href="https://github.com/Maps4HTML/validator-mapml">HTML-MapML Validator</a>
           <p>
             An experimental / work in progress fork of the validator.nu project 
             which validates MapML documents.  The objective is to validate HTML
-            including map markup as well as independent text/mapml documents.
+            including map markup as well as independent <code>text/mapml</code> documents.
           </p>
         </li>
         <li><a href="https://github.com/prushforth/htmlparser">HTML-MapML Parser</a>
           <p>
             An experimental / work in progress fork of the 
-            <a href="https://github.com/validator/htmlparser">validator.nu HTML parser</a>
+            <a href="https://github.com/validator/htmlparser">validator.nu HTML parser</a>.
+          </p>
+        </li>
+        <li><a href="https://github.com/Maps4HTML/pygeoapi-mapml-formatter">pygeoapi MapML Formatter Plugin</a>
+          <p>
+            MapML Formatter Plugin for
+            <a href="https://pygeoapi.io/">pygeoapi</a>.
+          </p>
+        </li>
+        <li><a href="https://github.com/Maps4HTML/MapMLServer">MapMLServer</a>
+          <p>
+            MapML tile servlet Maven Java project.
           </p>
         </li>
       </ul>


### PR DESCRIPTION
Adding the following links to the Software Projects section:
- experiments and web-map-docs (Fixes https://github.com/Maps4HTML/Maps4HTML.github.io/issues/27).
- pygeoapi-mapml-formatter
- MapMLServer

Also renamed "Validator.nu for MapML" to "HTML-MapML Validator".